### PR TITLE
use  input-keyboard-symbolic on non-KDE.

### DIFF
--- a/src/frontend/ibusfrontend/ibusfrontend.cpp
+++ b/src/frontend/ibusfrontend/ibusfrontend.cpp
@@ -677,7 +677,7 @@ void IBusFrontendModule::replaceIBus() {
                     while ((ret = waitpid(pid, &stat, WNOHANG)) <= 0) {
                         if (ret == 0) {
                             FCITX_DEBUG()
-                                << "ibus exit have ended yet, kill it.";
+                                << "ibus exit haven't ended yet, kill it.";
                             kill(pid, SIGKILL);
                             waitpid(pid, &stat, WNOHANG);
                             break;

--- a/src/im/keyboard/keyboard.cpp
+++ b/src/im/keyboard/keyboard.cpp
@@ -199,7 +199,7 @@ std::vector<InputMethodEntry> KeyboardEngine::listInputMethods() {
         result.push_back(std::move(
             InputMethodEntry(uniqueName, description, language, "keyboard")
                 .setLabel(layoutInfo.name)
-                .setIcon("input-keyboard-symbolic")
+                .setIcon("input-keyboard")
                 .setConfigurable(true)));
         for (const auto &variantInfo : layoutInfo.variantInfos) {
             auto language = findBestLanguage(isoCodes_, variantInfo.description,

--- a/src/modules/notificationitem/notificationitem.cpp
+++ b/src/modules/notificationitem/notificationitem.cpp
@@ -49,12 +49,16 @@ public:
     void activate(int, int) { parent_->instance()->toggle(); }
     void secondaryActivate(int, int) {}
     std::string iconName() {
+        std::string icon = "input-keyboard-symbolic";
         if (auto *ic = parent_->instance()->lastFocusedInputContext()) {
             if (const auto *entry = parent_->instance()->inputMethodEntry(ic)) {
-                return entry->icon();
+                icon = entry->icon();
             }
         }
-        return "input-keyboard-symbolic";
+        if (icon == "input-keyboard") {
+            return "input-keyboard-symbolic";
+        }
+        return icon;
     }
 
     std::string label() {

--- a/src/ui/kimpanel/kimpanel.cpp
+++ b/src/ui/kimpanel/kimpanel.cpp
@@ -25,6 +25,15 @@
 
 namespace fcitx {
 
+bool isKDE() {
+    std::string desktop;
+    auto *desktopEnv = getenv("XDG_CURRENT_DESKTOP");
+    if (desktopEnv) {
+        desktop = desktopEnv;
+    }
+    return desktop == "KDE";
+}
+
 enum class CursorRectMethod {
     SetSpotRect,
     SetRelativeSpotRect,
@@ -362,6 +371,12 @@ std::string Kimpanel::inputMethodStatus(InputContext *ic) {
             description = entry->name();
         }
     }
+
+    static const bool preferSymbolic = !isKDE();
+    if (preferSymbolic && icon == "input-keyboard") {
+        icon = "input-keyboard-symbolic";
+    }
+
     return stringutils::concat(
         "/Fcitx/im:", label.empty() ? description : label, ":", icon, ":",
         label.empty() ? "" : description, ":menu");


### PR DESCRIPTION
Plasma seems to have a better icon when input-keyboard is used.